### PR TITLE
refactor: make Heading an optional property passed to Main.Content 

### DIFF
--- a/src/common/Main.tsx
+++ b/src/common/Main.tsx
@@ -12,6 +12,7 @@ import {
 
 import { DeviceIcon, deviceName } from '../features/device/deviceGuides';
 import { DeviceWithRequiredSerialNumber } from '../features/device/deviceSlice';
+import Heading from './Heading';
 
 const Header = ({ device }: { device?: DeviceWithRequiredSerialNumber }) => (
     <div className="tw-flex tw-h-16 tw-w-full tw-flex-row tw-items-center tw-justify-around tw-bg-gray-700 tw-px-12 tw-py-4 tw-text-base tw-text-white">
@@ -38,15 +39,24 @@ const Header = ({ device }: { device?: DeviceWithRequiredSerialNumber }) => (
 
 const Content = ({
     className = '',
+    heading,
     children,
 }: {
     className?: string;
+    heading?: string;
     children: ReactNode;
 }) => (
-    <div
-        className={`tw-flex tw-flex-col tw-items-center tw-justify-center tw-p-8 tw-text-center tw-text-sm tw-text-gray-700 ${className}`}
-    >
-        {children}
+    <div className="tw-flex tw-w-full tw-flex-col tw-items-center tw-justify-center tw-p-8 tw-text-center tw-text-sm tw-text-gray-700">
+        {heading && (
+            <div className="tw-pb-10">
+                <Heading>{heading}</Heading>
+            </div>
+        )}
+        <div
+            className={`tw-flex tw-flex-col tw-items-center tw-justify-center ${className}`}
+        >
+            {children}
+        </div>
     </div>
 );
 

--- a/src/features/steps/Apps.tsx
+++ b/src/features/steps/Apps.tsx
@@ -14,7 +14,6 @@ import {
 
 import { useAppSelector } from '../../app/store';
 import { Back } from '../../common/Back';
-import Heading from '../../common/Heading';
 import Main from '../../common/Main';
 import { Next } from '../../common/Next';
 import { deviceApps } from '../device/deviceGuides';
@@ -141,8 +140,10 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content className="tw-gap-6">
-                <Heading>Install recommended apps</Heading>
+            <Main.Content
+                heading="Install recommended apps"
+                className="tw-gap-6"
+            >
                 {recommendedApps.some(app => !apps.isInstalled(app)) ? (
                     <p>You can always add and remove apps later.</p>
                 ) : (

--- a/src/features/steps/Connect.tsx
+++ b/src/features/steps/Connect.tsx
@@ -8,7 +8,6 @@ import React, { useEffect, useState } from 'react';
 import { Spinner } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useAppDispatch, useAppSelector } from '../../app/store';
-import Heading from '../../common/Heading';
 import Main from '../../common/Main';
 import { isSupportedDevice } from '../device/deviceGuides';
 import { getConnectedDevices, selectDevice } from '../device/deviceSlice';
@@ -52,9 +51,8 @@ export default () => {
 
     return (
         <Main>
-            <Main.Content>
-                <Heading>Connect a Nordic kit to your PC</Heading>
-                <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-4 tw-pt-4">
+            <Main.Content heading="Connect a Nordic kit to your PC">
+                <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-4">
                     <Spinner size="sm" />
                     <p>Searching for devices</p>
                     {longSearchDuration && (

--- a/src/features/steps/Develop.tsx
+++ b/src/features/steps/Develop.tsx
@@ -12,7 +12,6 @@ import {
 
 import { useAppSelector } from '../../app/store';
 import { Back } from '../../common/Back';
-import Heading from '../../common/Heading';
 import Main from '../../common/Main';
 import { Next } from '../../common/Next';
 import { getSelectedDeviceUnsafely } from '../device/deviceSlice';
@@ -21,9 +20,11 @@ export default () => {
     const device = useAppSelector(getSelectedDeviceUnsafely);
     return (
         <Main device={device}>
-            <Main.Content className="tw-max-w-sm">
-                <Heading>Install nRF Connect SDK and Toolchain</Heading>
-                <div className="tw-flex tw-flex-col tw-items-center tw-gap-4 tw-pt-10">
+            <Main.Content
+                heading="Install nRF Connect SDK and Toolchain"
+                className="tw-max-w-sm"
+            >
+                <div className="tw-flex tw-flex-col tw-items-center tw-gap-4">
                     <p>
                         The nRF Connect SDK is where you begin building
                         low-power wireless applications with Nordic

--- a/src/features/steps/Finish.tsx
+++ b/src/features/steps/Finish.tsx
@@ -13,7 +13,6 @@ import {
 
 import { useAppSelector } from '../../app/store';
 import { Back } from '../../common/Back';
-import Heading from '../../common/Heading';
 import Main from '../../common/Main';
 import { Next } from '../../common/Next';
 import { getSelectedDeviceUnsafely } from '../device/deviceSlice';
@@ -23,9 +22,8 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content className="tw-max-w-sm">
-                <Heading>Finished Quickstart</Heading>
-                <div className="tw-flex tw-flex-col tw-gap-4 tw-pt-10">
+            <Main.Content heading="Finished Quickstart" className="tw-max-w-sm">
+                <div className="tw-flex tw-flex-col tw-gap-4">
                     <p>You now have finished all the steps</p>
                     <p>
                         Quickstart can be opened at any time from nRF Connect

--- a/src/features/steps/Learn.tsx
+++ b/src/features/steps/Learn.tsx
@@ -13,7 +13,6 @@ import {
 
 import { useAppSelector } from '../../app/store';
 import { Back } from '../../common/Back';
-import Heading from '../../common/Heading';
 import Main from '../../common/Main';
 import { Next } from '../../common/Next';
 import { deviceLinks, deviceName } from '../device/deviceGuides';
@@ -25,12 +24,12 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content>
-                <Heading>
-                    We recommend these resources for learning more about{' '}
-                    {deviceName(device)}
-                </Heading>
-                <div className="tw-flex tw-flex-col tw-items-center tw-gap-4 tw-pt-10">
+            <Main.Content
+                heading={`We recommend these resources for learning more about ${deviceName(
+                    device
+                )}`}
+            >
+                <div className="tw-flex tw-flex-col tw-items-center tw-gap-4">
                     {deviceLinks(device, choice).map(({ label, href }) => (
                         <Button
                             key={label}

--- a/src/features/steps/Personalize.tsx
+++ b/src/features/steps/Personalize.tsx
@@ -13,7 +13,6 @@ import {
 
 import { useAppSelector } from '../../app/store';
 import { Back } from '../../common/Back';
-import Heading from '../../common/Heading';
 import Main from '../../common/Main';
 import { Next } from '../../common/Next';
 import { getSelectedDeviceUnsafely } from '../device/deviceSlice';
@@ -28,9 +27,8 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content>
-                <Heading>First, give your kit a custom name</Heading>
-                <div className="tw-flex tw-flex-col tw-items-center tw-gap-12 tw-pt-10">
+            <Main.Content heading="First, give your kit a custom name">
+                <div className="tw-flex tw-flex-col tw-items-center tw-gap-12">
                     <div className="tw-flex tw-w-64 tw-flex-col tw-items-center">
                         <div className="tw-self-end tw-text-xs">{`${nickname.length}/${maxLength}`}</div>
                         <input

--- a/src/features/steps/SelectFirmware.tsx
+++ b/src/features/steps/SelectFirmware.tsx
@@ -14,7 +14,6 @@ import {
 
 import { useAppDispatch, useAppSelector } from '../../app/store';
 import { Back } from '../../common/Back';
-import Heading from '../../common/Heading';
 import Main from '../../common/Main';
 import { Next } from '../../common/Next';
 import { Choice, deviceEvaluationChoices } from '../device/deviceGuides';
@@ -29,8 +28,7 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content className="tw-gap-8">
-                <Heading>Select application</Heading>
+            <Main.Content heading="Select application" className="tw-gap-8">
                 <p>
                     This will program the application and the latest modem
                     firmware

--- a/src/features/steps/program/Error.tsx
+++ b/src/features/steps/program/Error.tsx
@@ -14,7 +14,6 @@ import {
 
 import { useAppDispatch, useAppSelector } from '../../../app/store';
 import { Back } from '../../../common/Back';
-import Heading from '../../../common/Heading';
 import Main from '../../../common/Main';
 import { getSelectedDeviceUnsafely, setChoice } from '../../device/deviceSlice';
 import { startProgramming } from './programEffects';
@@ -27,9 +26,8 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content>
-                <Heading>Failed to program device</Heading>
-                <div className="tw-max-w-sm tw-pt-10">
+            <Main.Content heading="Failed to program device">
+                <div className="tw-max-w-sm">
                     <p>{describeError(error)}</p>
                 </div>
             </Main.Content>

--- a/src/features/steps/program/NoDeviceConnected.tsx
+++ b/src/features/steps/program/NoDeviceConnected.tsx
@@ -8,7 +8,6 @@ import React, { useEffect } from 'react';
 import { Spinner } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useAppDispatch, useAppSelector } from '../../../app/store';
-import Heading from '../../../common/Heading';
 import Main from '../../../common/Main';
 import {
     getSelectedDeviceUnsafely,
@@ -29,9 +28,8 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content>
-                <Heading>Device not connected</Heading>
-                <div className="tw-flex tw-max-w-sm tw-flex-col tw-items-center tw-gap-4 tw-pt-4">
+            <Main.Content heading="Device not connected">
+                <div className="tw-flex tw-max-w-sm tw-flex-col tw-items-center tw-gap-4">
                     <Spinner size="sm" />
                     <p>
                         Ensure that your device is connected in order to program

--- a/src/features/steps/program/Program.tsx
+++ b/src/features/steps/program/Program.tsx
@@ -10,7 +10,6 @@ import { Progress } from '@nordicsemiconductor/nrf-device-lib-js';
 import { Button, Spinner } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useAppSelector } from '../../../app/store';
-import Heading from '../../../common/Heading';
 import Main from '../../../common/Main';
 import { getSelectedDeviceUnsafely } from '../../device/deviceSlice';
 import { getProgrammingProgress } from './programSlice';
@@ -34,9 +33,11 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content className="tw-w-full tw-max-w-3xl">
-                <Heading>Programming</Heading>
-                <div className="tw-py-4">
+            <Main.Content
+                heading="Programming"
+                className="tw-w-full tw-max-w-3xl"
+            >
+                <div className="tw-pb-4">
                     <Spinner size="sm" />
                 </div>
                 <p>This might take a few minutes. Please wait.</p>

--- a/src/features/steps/program/Success.tsx
+++ b/src/features/steps/program/Success.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 
 import { useAppDispatch, useAppSelector } from '../../../app/store';
 import { Back } from '../../../common/Back';
-import Heading from '../../../common/Heading';
 import Main from '../../../common/Main';
 import { Next } from '../../../common/Next';
 import { getSelectedDeviceUnsafely, setChoice } from '../../device/deviceSlice';
@@ -19,9 +18,8 @@ export default () => {
 
     return (
         <Main device={device}>
-            <Main.Content>
-                <Heading>Success!</Heading>
-                <div className="tw-max-w-sm tw-pt-10">
+            <Main.Content heading="Success!">
+                <div className="tw-max-w-sm">
                     <p>Device was programmed successfully.</p>
                 </div>
             </Main.Content>


### PR DESCRIPTION
Noticed that all steps (except Introduction) had a Heading with text below.
The heading itself seemed to mostly have 40px space below with some variance but it seemed generic enough to move into the Main.Content.

Waiting for some newer sketches and clarification if this generalization of designs for the steps is fine.