### PR TITLE
Fix: required version of nRF Connect  for Desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",
     "engines": {
-        "nrfconnect": ">=4.0.0"
+        "nrfconnect": ">=4.2.0"
     },
     "main": "dist/bundle.js",
     "nrfConnectForDesktop": {


### PR DESCRIPTION
4.2.0 is needed because it added support for nrfutil.