### PR TITLE
Fix: Disable feedback button on empty input

### DIFF
--- a/src/features/steps/finish/Feedback.tsx
+++ b/src/features/steps/finish/Feedback.tsx
@@ -20,6 +20,7 @@ export default ({ back, next }: { back: () => void; next: () => void }) => {
             <Main.Content heading="Give feedback">
                 <form>
                     <textarea
+                        placeholder="Type your feedback here..."
                         name="feedback-text"
                         className="tw-h-44 tw-w-full tw-resize-none tw-border tw-border-gray-200 tw-p-2 focus:tw-outline-none"
                         required


### PR DESCRIPTION
[NCD-521](https://nordicsemi.atlassian.net/browse/NCD-521):

Until the users enter non-whitespace input, the feedback button is now disabled.

