### PR TITLE
Specify supported devices in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     },
     "main": "dist/bundle.js",
     "nrfConnectForDesktop": {
+        "supportedDevices": [
+            "PCA10090",
+            "PCA10153"
+        ],
         "html": "dist/index.html",
         "nrfutil": {
             "device": [


### PR DESCRIPTION
This isn't supported yet by the launcher but in the future the launcher can read this to display which devices are supported by the installed version of this app.