### PR TITLE
Fix: Long nicknames broke the table

### DIFF
--- a/src/features/connect/Select.tsx
+++ b/src/features/connect/Select.tsx
@@ -32,6 +32,7 @@ export default () => {
 
     const items = connectedDevices.map(device => {
         const isSelected = selectedItem?.id === device.serialNumber;
+        const nickname = getPersistedNickname(device.serialNumber);
 
         return {
             id: device.serialNumber,
@@ -63,7 +64,12 @@ export default () => {
                     >
                         {device.serialNumber}
                     </p>
-                    <p>{getPersistedNickname(device.serialNumber) || ''}</p>
+                    <p
+                        className="tw-max-w-[11rem] tw-truncate"
+                        title={nickname}
+                    >
+                        {nickname}
+                    </p>
                 </div>
             ),
         };


### PR DESCRIPTION
[NCD-519](https://nordicsemi.atlassian.net/browse/NCD-519):

Too long nicknames (e.g. `WWWWWWWWWWWWWWWWWWWO`) are now truncated with an ellipsis in the table where a device is selected. The full name is always placed in the CSS title property, so hovering over the title will show the full nickname.

![image](https://github.com/NordicPlayground/pc-nrfconnect-quickstart/assets/260705/aabaea20-9529-4f24-8851-a4a510712464)
