### PR TITLE
Enable resetting device nickname

### DIFF
--- a/src/features/steps/Rename.tsx
+++ b/src/features/steps/Rename.tsx
@@ -19,10 +19,11 @@ import { getSelectedDeviceUnsafely } from '../device/deviceSlice';
 
 export default () => {
     const device = useAppSelector(getSelectedDeviceUnsafely);
+    const previousNickname = device
+        ? getPersistedNickname(device.serialNumber)
+        : '';
 
-    const [nickname, setNickname] = React.useState(
-        device ? getPersistedNickname(device.serialNumber) : ''
-    );
+    const [nickname, setNickname] = React.useState(previousNickname);
     const maxLength = 20;
 
     return (
@@ -52,12 +53,14 @@ export default () => {
                 <Next
                     onClick={next => {
                         const newNickname = nickname.trim();
-                        persistNickname(device.serialNumber, newNickname);
-                        usageData.sendUsageData(
-                            newNickname.length > 0
-                                ? 'Set device nickname'
-                                : 'Reset device nickname'
-                        );
+                        if (newNickname !== previousNickname) {
+                            persistNickname(device.serialNumber, newNickname);
+                            usageData.sendUsageData(
+                                newNickname.length > 0
+                                    ? 'Set device nickname'
+                                    : 'Reset device nickname'
+                            );
+                        }
 
                         next();
                     }}


### PR DESCRIPTION
[NCD-520](https://nordicsemi.atlassian.net/browse/NCD-520):

It was impossible to remove the nickname from a device once it was set. Now entering an empty nickname will reset the nickname to the default.

