### PR TITLE
Add parameters when opening VS Code

### DIFF
--- a/src/features/device/deviceGuides.tsx
+++ b/src/features/device/deviceGuides.tsx
@@ -78,6 +78,7 @@ const choice = z.object({
     description: z.string(),
     documentation: link,
     firmware: z.array(firmware),
+    sampleSource: z.string(),
 });
 
 export type Choice = z.infer<typeof choice>;

--- a/src/features/device/pca10090.json
+++ b/src/features/device/pca10090.json
@@ -25,6 +25,7 @@
                     "label": "Serial LTE Modem",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/serial_lte_modem/README.html"
                 },
+                "sampleSource": "nrf/applications/serial_lte_modem",
                 "firmware": [
                     {
                         "core": "Modem",
@@ -52,6 +53,7 @@
                     "label": "Asset Tracker V2",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html"
                 },
+                "sampleSource": "nrf/applications/asset_tracker_v2",
                 "firmware": [
                     {
                         "core": "Modem",
@@ -79,6 +81,7 @@
                     "label": "Modem Shell",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/cellular/modem_shell/README.html"
                 },
+                "sampleSource": "nrf/samples/cellular/modem_shell",
                 "firmware": [
                     {
                         "core": "Modem",

--- a/src/features/device/pca10153.json
+++ b/src/features/device/pca10153.json
@@ -24,6 +24,7 @@
                     "label": "Serial LTE Modem",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/serial_lte_modem/README.html"
                 },
+                "sampleSource": "nrf/applications/serial_lte_modem",
                 "firmware": [
                     {
                         "core": "Modem",
@@ -51,6 +52,7 @@
                     "label": "Asset Tracker V2",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html"
                 },
+                "sampleSource": "nrf/applications/asset_tracker_v2",
                 "firmware": [
                     {
                         "core": "Modem",
@@ -78,6 +80,7 @@
                     "label": "Modem Shell",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/cellular/modem_shell/README.html"
                 },
+                "sampleSource": "nrf/samples/cellular/modem_shell",
                 "firmware": [
                     {
                         "core": "Modem",

--- a/src/features/device/pca10171.json
+++ b/src/features/device/pca10171.json
@@ -24,6 +24,7 @@
                     "label": "Serial LTE Modem",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/serial_lte_modem/README.html"
                 },
+                "sampleSource": "nrf/applications/serial_lte_modem",
                 "firmware": [
                     {
                         "core": "Modem",
@@ -51,6 +52,7 @@
                     "label": "Asset Tracker V2",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html"
                 },
+                "sampleSource": "nrf/applications/asset_tracker_v2",
                 "firmware": [
                     {
                         "core": "Modem",
@@ -78,6 +80,7 @@
                     "label": "Modem Shell",
                     "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/cellular/modem_shell/README.html"
                 },
+                "sampleSource": "nrf/samples/cellular/modem_shell",
                 "firmware": [
                     {
                         "core": "Modem",

--- a/src/features/steps/develop/OpenVsCode.test.ts
+++ b/src/features/steps/develop/OpenVsCode.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { queryParamsString } from './OpenVsCode';
+
+describe('queryParamsString', () => {
+    it('converts all parameters to a query string', () => {
+        expect(
+            queryParamsString({
+                aParam: 'aValue',
+                anotherParam: 'anotherValue',
+            })
+        ).toMatch(
+            /aParam=aValue&anotherParam=anotherValue|anotherParam=anotherValue&aParam=aValue/
+        );
+    });
+
+    it('escapes special characters', () => {
+        expect(
+            queryParamsString({ param: 'special characters follow /?&=\\' })
+        ).toBe('param=special%20characters%20follow%20%2F%3F%26%3D%5C');
+    });
+
+    it('filters out undefined parameters', () => {
+        expect(
+            queryParamsString({
+                param: 'something',
+                notDefined: undefined,
+                notSet: null,
+            })
+        ).toBe('param=something');
+    });
+});


### PR DESCRIPTION
[VSC-2085](https://nordicsemi.atlassian.net/browse/VSC-2085)

This will allow the VS Code extension to offer using the same sample, select the same device and device type, as were already chosen in the quick start app.