### PR TITLE
fix: update outdated or incorrect links

### DIFF
--- a/src/features/device/pca10090.json
+++ b/src/features/device/pca10090.json
@@ -44,7 +44,7 @@
                         "file": "nrf9160dk_serial_lte_modem_debug_2024-03-13_af2b60d2.hex",
                         "link": {
                             "label": "Serial LTE Modem",
-                            "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/serial_lte_modem/README.html"
+                            "href": "https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/serial_lte_modem/README.html"
                         }
                     }
                 ]
@@ -76,7 +76,7 @@
                         "file": "nrf9160dk_asset_tracker_v2_debug_2024-03-13_af2b60d2.hex",
                         "link": {
                             "label": "Asset Tracker v2",
-                            "href": "https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/applications/asset_tracker_v2/README.html"
+                            "href": "https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/applications/asset_tracker_v2/README.html"
                         }
                     }
                 ]

--- a/src/features/steps/develop/CLI.tsx
+++ b/src/features/steps/develop/CLI.tsx
@@ -21,10 +21,10 @@ export default () => {
             <Main.Content heading="Command Line">
                 <div className="tw-flex tw-flex-col tw-gap-6">
                     <Resource
-                        label="Install nRF Connect SDK and toolchain manually"
-                        description="Install manually using the command line"
+                        label="Installing the nRF Connect SDK"
+                        description="Install the nRF Connect toolchain and SDK."
                         link={{
-                            href: 'https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/installation/installing.html',
+                            href: 'https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation/install_ncs.html',
                             label: 'Manual installation instructions',
                         }}
                     />
@@ -32,7 +32,7 @@ export default () => {
                         label="nRF Util"
                         description="A modular command line tool, enabling power users to manage Nordic Semiconductor devices and support automation."
                         link={{
-                            href: 'https://www.nordicsemi.com/Products/Development-tools/nrf-util',
+                            href: 'https://docs.nordicsemi.com/bundle/nrfutil/page/README.html',
                             label: 'nRF Util documentation',
                         }}
                     />
@@ -40,7 +40,7 @@ export default () => {
                         label="West"
                         description="A tool for managing multiple Git repositories and versions."
                         link={{
-                            href: 'https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/develop/west',
+                            href: 'https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/develop/west/index.html',
                             label: 'West overview',
                         }}
                     />


### PR DESCRIPTION
Replaced outdated or incorrect links in the app.
Follow-up to #190.