### PR TITLE
fix: if flow step undefined it's Connect

### DIFF
--- a/src/features/flow/index.tsx
+++ b/src/features/flow/index.tsx
@@ -28,7 +28,7 @@ const useLogSteps = () => {
 
     // Telemetry when user changes step
     useEffect(() => {
-        const step = flow[currentStepIndex];
+        const step = flow[currentStepIndex] || 'Connect';
 
         logger.debug(`Changed step: ${step}`);
         telemetry.sendEvent('Changed step', { step });


### PR DESCRIPTION
Theoretically it doesn't have to be connect but practically it always is