### PR TITLE
doc: rename app + other edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-quickstart?branchName=master)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=10&branchName=master)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-The Quick Start app is a cross-platform tool for guided setup and
-installation procedures of Nordic Semiconductor devices.
+The Quick Start app is a cross-platform tool for guided setup and installation
+procedures of Nordic Semiconductor devices.
 
 ## Installation
 
@@ -19,8 +19,8 @@ application.
 
 ## Documentation
 
-The Quick Start app is meant as an onboarding tool and it does not come with
-its own documentation. The onboarding steps will be different for each of the
+The Quick Start app is meant as an onboarding tool and it does not come with its
+own documentation. The onboarding steps will be different for each of the
 [supported devices](https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html).
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# nRF Connect Quick Start
+# Quick Start app
 
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-quickstart?branchName=master)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=10&branchName=master)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-nRF Connect Quick Start is a cross-platform tool for guided setup and
+The Quick Start app is a cross-platform tool for guided setup and
 installation procedures of Nordic Semiconductor devices.
 
 ## Installation
 
-nRF Connect Quick Start is installed from nRF Connect from Desktop. For detailed
+The Quick Start app is installed from nRF Connect from Desktop. For detailed
 steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.
@@ -19,7 +19,7 @@ application.
 
 ## Documentation
 
-nRF Connect Quick Start is meant as an onboarding tool and it does not come with
+The Quick Start app is meant as an onboarding tool and it does not come with
 its own documentation. The onboarding steps will be different for each of the
 [supported devices](https://docs.nordicsemi.com/bundle/nrf-connect-quickstart/page/index.html).
 

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,11 +1,11 @@
-# nRF Connect Quick Start
+# {{app_name}}
 
-nRF Connect Quick Start is a cross-platform tool for guided setup and installation procedures of Nordic Semiconductor devices, available as one of the applications in [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
+The {{app_name}} is a cross-platform tool for guided setup and installation procedures of Nordic Semiconductor devices, available as one of the applications in [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
 
 ## Installation
 
-You can run Quick Start when you [download and install nRF Connect for Desktop](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop/Download).
-You will be prompted to try out nRF Connect Quick Start when you open the launcher.
+You can run the {{app_name}} when you [download and install nRF Connect for Desktop](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop/Download).
+You will be prompted to try out the {{app_name}} when you open the launcher.
 
 After installing and opening the app from nRF Connect for Desktop, connect your device to your machine using an USB cable and follow the steps in the application.
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: nRF Connect Quick Start documentation
+site_name: Quick Start app documentation
 site_url:
 use_directory_urls: false
 
@@ -30,7 +30,7 @@ extra_css:
   - stylesheets/style.css
 
 copyright:
-  Copyright &copy; 2023
+  Copyright &copy; 2023-2024
 
 markdown_extensions:
   - abbr
@@ -42,9 +42,6 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed
   - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 4
@@ -56,6 +53,7 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
+  app_name: Quick Start app
 
 nav:
   - Home: index.md

--- a/doc/zoomin/custom.properties
+++ b/doc/zoomin/custom.properties
@@ -1,3 +1,3 @@
 manual.name=nrf-connect-quickstart
-booktitle=nRF Connect Quick Start
-shortdesc=Documentation for the nRF Connect Quick Start application.
+booktitle=Quick Start app
+shortdesc=Documentation for the Quick Start application.


### PR DESCRIPTION
Dropped nRF Connect from app name.
Updated copyright year.
Removed unused extensions.
Added app_name abbreviation.
NCD-1066.