### PR TITLE
fix: change vComIndex for verify step for 5340 back to 1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,10 +4,6 @@
 
 -   Text in the Info step for the nRF54L15 DK.
 
-### Fixed
-
--   The verify step for the nRF5340 DK always failed.
-
 ## 1.3.0 - 2025-06-24
 
 ### Added

--- a/src/features/flows/nRF5340/index.ts
+++ b/src/features/flows/nRF5340/index.ts
@@ -94,21 +94,21 @@ const verifyConfig = [
     {
         ref: 'Hello World',
         config: {
-            vComIndex: 2,
+            vComIndex: 1,
             regex: /(\*{3} Booting nRF Connect SDK .* \*{3}\r\n\*{3} Using Zephyr OS .* \*{3}\r\nHello World! nrf5340dk\/nrf5340)/,
         },
     },
     {
         ref: 'Peripheral LED Button Service',
         config: {
-            vComIndex: 2,
+            vComIndex: 1,
             regex: /(\*{3} Using nRF Connect SDK .* \*{3}\r\n\*{3} Using Zephyr OS .* \*{3}\r\nStarting Bluetooth Peripheral LBS example)/,
         },
     },
     {
         ref: 'Peripheral UART',
         config: {
-            vComIndex: 2,
+            vComIndex: 1,
             regex: /(\*{3} Using nRF Connect SDK .* \*{3}\r\n\*{3} Using Zephyr OS .* \*{3}\r\nStarting Nordic UART service example)/,
         },
     },


### PR DESCRIPTION
This differs on hardware version. We will continue to target 1 (which works for the newer quickstart versions) and add a proper fix which handles all cases later