### PR TITLE
Set fixed size of the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
             "PCA10153"
         ],
         "html": "dist/index.html",
+        "fixedSize": {
+            "width": 800,
+            "height": 550
+        },
         "nrfutil": {
             "device": [
                 "2.13.2"


### PR DESCRIPTION
So far, the launcher included a special hard coded size for the Quick Start app. But the next version of the launcher will allow any app to specify a fixed size. Setting it here means we can remove the special case in the launcher after a few releases.

https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/pull/1199