### PR TITLE
Empty string as a default app name at evaluate step

### DIFF
--- a/src/common/Resource.tsx
+++ b/src/common/Resource.tsx
@@ -116,7 +116,7 @@ export const AppResourceButton = ({
     return (
         <div className="tw-flex tw-flex-row tw-items-center tw-justify-between tw-gap-10">
             <div className="tw-w-80">
-                <div>
+                <div className="tw-min-h-5">
                     <b>{title || displayName}</b>
                 </div>
                 {description}

--- a/src/common/Resource.tsx
+++ b/src/common/Resource.tsx
@@ -99,7 +99,7 @@ export const AppResourceButton = ({
     onInstallFinish?: () => void;
 }) => {
     const device = useAppSelector(getSelectedDeviceUnsafely);
-    const [displayName, setDisplayName] = useState(app);
+    const [displayName, setDisplayName] = useState('');
     const [isInstalling, setIsInstalling] = useState(false);
     const path =
         vComIndex !== undefined


### PR DESCRIPTION
.. so UI does not blink when strings with different length are supplied
